### PR TITLE
Fix child players get stuck on zero volume

### DIFF
--- a/music_assistant/server/controllers/players.py
+++ b/music_assistant/server/controllers/players.py
@@ -460,11 +460,10 @@ class PlayerController(CoreController):
         cur_volume = group_player.group_volume
         new_volume = volume_level
         volume_dif = new_volume - cur_volume
-        volume_dif_percent = 1 + new_volume / 100 if cur_volume == 0 else volume_dif / cur_volume
         coros = []
         for child_player in self._get_child_players(group_player, True):
             cur_child_volume = child_player.volume_level
-            new_child_volume = int(cur_child_volume + (cur_child_volume * volume_dif_percent))
+            new_child_volume = int(cur_child_volume + volume_dif)
             coros.append(self.cmd_volume_set(child_player.player_id, new_child_volume))
         await asyncio.gather(*coros)
 


### PR DESCRIPTION
Originally raised here https://github.com/music-assistant/hass-music-assistant/issues/1504

The suggested fix however would result in child volumes not going below 1.  Looking at the current behavior the use of average of the powered child volumes for the group is good however the percentage change gives rise to unexpected results. Apart fro the zero case I also tried setting one speaker to 46 and another to 10 which gave a group volume of 28. Changing the group volume to 56 resulted in the first player going to 98 and the other to 14. I don't think this is expected. Therefore this PR suggests changing to relative movement. With the player volumes limited to 0 and 100 I think the result should be OK but I haven't tested it to see what the UX is like.